### PR TITLE
src/meta-libs.ts: Don't accept password on null param.

### DIFF
--- a/src/meta-lib.ts
+++ b/src/meta-lib.ts
@@ -272,7 +272,7 @@ export class MetaLib extends BasicInterface {
             );
           }
           case Type.VulnerabilityAction.Password: {
-            if (optArgsRaw === '' || !isAlphaNumeric(optArgsRaw)) {
+            if (optArgsRaw === null || optArgsRaw === '' || !isAlphaNumeric(optArgsRaw)) {
               output += `success!\nExecuting payload...\nerror: can't change password for user ${vulTargetUser.username}. Password must be alphanumeric.`;
               ctx.handler.outputHandler.print(ctx, output);
               return Promise.resolve(DefaultType.False);


### PR DESCRIPTION
Previously, we would indicate that the password had been successfully changed even if the optParam was null. This fixes it to be consistent with the game.